### PR TITLE
Make testsuite `emu/plugins/tdl` pass on Go 1.20+

### DIFF
--- a/src/emu/plugins/tdl/tdl_test.go
+++ b/src/emu/plugins/tdl/tdl_test.go
@@ -561,6 +561,7 @@ func TestTypeDef1(t *testing.T) {
 		initJSON:     [][]byte{[]byte(initJson)},
 		duration:     10 * time.Second,
 		clientsToSim: 1,
+		seed:         1,
 	}
 	a.Run(t, true)
 }


### PR DESCRIPTION
Prior to Go 1.20 the pseudo-random number generator was seeded like Seed(1) at program startup, but in later releases the generator is seeded randomly.

Since the testcase `typeDef1` uses the `rand` operation the testcase output does not always match the expected file:
`unit-test/exp/typeDef1.json`.
This is due to the different random order in Go 1.20+.
By setting seed=1 via its `TdlTestBase`, as previously done by Go itself, we get the same result in all Go version.

**References:**
Testcase: `"params": { "size": 6, "offset": 0, "op": "rand", "list": ["TRex", "Cisco", "Golang"] }`

Go doc: https://pkg.go.dev/math/rand@master#Seed