### PR TITLE
Fix build failure in `trex-emu-proxy`

### DIFF
--- a/src/cmd-proxy/trex-emu-proxy.go
+++ b/src/cmd-proxy/trex-emu-proxy.go
@@ -172,7 +172,7 @@ func (o *CZmqProxy) MainLoop() {
 		select {
 		case pkt := <-o.rawSocket.GetC(): // raw socket rx -> send to veth
 			o.OnRxPkt(pkt)
-		case <-o.tctx.C(): // timer flush
+		case <-o.tctx.GetTimerCtx().GetC(): // timer flush
 			o.tctx.HandleMainTimerTicks()
 		case msg := <-o.tctx.Veth.GetC(): // zmq -> raw_socket
 			o.tctx.Veth.OnRxStream(msg) // call  HandleRxPacket

--- a/src/cmd-proxy/trex-emu-proxy.go
+++ b/src/cmd-proxy/trex-emu-proxy.go
@@ -30,7 +30,6 @@ const (
 )
 
 type MainArgs struct {
-	port       *int
 	vethPort   *int
 	verbose    *bool
 	monitor    *bool
@@ -179,8 +178,6 @@ func (o *CZmqProxy) MainLoop() {
 		}
 		o.tctx.Veth.FlushTx()
 	}
-	o.tctx.Veth.SimulatorCleanup()
-	o.tctx.MPool.ClearCache()
 }
 
 func RunCoreZmq(args *MainArgs) {


### PR DESCRIPTION
This PR fixes the error when attempting to build `trex-emu-proxy` with:
`go install cmd-proxy/trex-emu-proxy.go`

The API to get the timer channel changed via c870182a4524304db8acca78ac561fb59d16ee8f and the new API is now used.

Additionally the following issues, indicated by golangci-lint, are fixed:
```    
    cmd-proxy/trex-emu-proxy.go:33:2: field `port` is unused (unused)
            port       *int
            ^
    cmd-proxy/trex-emu-proxy.go:182:2: unreachable: unreachable code (govet)
            o.tctx.Veth.SimulatorCleanup()
            ^
```   
No need for cleanups since when the process is terminated from shell it will exit in the MainLoop (no signal handling exist).
