### PR TITLE
[WIP] Add support for large UDP packets

### DIFF
--- a/src/emu/plugins/transport_example/example.go
+++ b/src/emu/plugins/transport_example/example.go
@@ -25,6 +25,7 @@ const (
 )
 
 type TransEInit struct {
+	Network  string `json:"network"`
 	Addr     string `json:"addr"`
 	DataSize uint32 `json:"size"`
 	Loops    uint32 `json:"loops"`
@@ -134,7 +135,7 @@ func NewTransportEClient(ctx *core.PluginCtx, initJson []byte) (*core.PluginBase
 	nsplg := o.Ns.PluginCtx.GetOrCreate(TRANS_E_PLUG)
 	o.tranNsPlug = nsplg.Ext.(*PluginTransportENs)
 
-	o.cfg = TransEInit{Addr: "48.0.0.1:80", DataSize: 10, Loops: 1}
+	o.cfg = TransEInit{Network: "tcp", Addr: "48.0.0.1:80", DataSize: 10, Loops: 1}
 	ctx.Tctx.UnmarshalValidate(initJson, &o.cfg)
 	o.b = make([]byte, o.cfg.DataSize)
 	for i := 0; i < int(o.cfg.DataSize-1); i++ {
@@ -222,11 +223,14 @@ func (o *PluginTransportEClient) OnEvent(msg string, a, b interface{}) {
 		if resolvedIPv4 {
 			// now we can dial
 			o.ctx = transport.GetTransportCtx(o.Client)
-			s, err := o.ctx.Dial("tcp", o.cfg.Addr, o, nil, nil, 0)
+			s, err := o.ctx.Dial(o.cfg.Network, o.cfg.Addr, o, nil, nil, 0)
 			if err != nil {
 				return
 			}
 			o.s = s
+			if o.cfg.Network == "udp" {
+				o.startLoop()
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is an initial implementation to handle UDP data that wont fit in a single IP packet due to the MTU size.
Sent data is put in IPv4 fragments and incoming fragments are defragmented.

This is mainly a PR to request input for the idea and I believe some refactoration and improvements are needed.

It's been function-tested via a TAP interface and running a script like [this](https://github.com/Nordix/trex-core/commit/482414d541fc51dd5786bd3ad7015004624dd230).

Any comments or ideas are welcomed.
Adresses #25