### PR TITLE
Update mbuf.go: increasing MAX_PACKET_SIZE

### DIFF
--- a/src/emu/core/mbuf.go
+++ b/src/emu/core/mbuf.go
@@ -42,7 +42,7 @@ const lMBUF_INVALID_PORT = 0xffff
 const lIND_ATTACHED_MBUF = 0x2
 
 //MAX_PACKET_SIZE the maximum packet size
-const MAX_PACKET_SIZE uint16 = 9 * 1024
+const MAX_PACKET_SIZE uint16 = 10 * 1024
 const MBUF_RX_POOL_SIZE = 2048 // pool used by rx size
 
 // MbufPoll cache of mbufs per packet size


### PR DESCRIPTION
The existing size is not sufficient and triggers a panic if an ingress packet is larger.
This panic was seen when the IGMP plugin has 10K+ IGMPv3 states. 

Run ZMQ server on [RPC:4510, RX: IPC, TX:IPC]
Recovered from panic:  MbufPoll.Alloc size is too big 9226 
Stack trace:
goroutine 1 [running]:
main.captureStackTrace()
        /ws/alexkr-sjc/emu/src/cmd/trex-emu.go:193 +0x3d
main.main.func1()
        /ws/alexkr-sjc/emu/src/cmd/trex-emu.go:201 +0x65
panic({0x9c9660?, 0xc000246000?})
        /ws/alexkr-sjc/go/src/runtime/panic.go:792 +0x132
emu/core.(*MbufPoll).Alloc(0xc000090000?, 0x7ee4?)
        /ws/alexkr-sjc/emu/src/emu/core/mbuf.go:113 +0xbf
emu/core.(*VethIFZmq).OnRxStream(0xc00026e2d0, {0xc000e70500, 0x2412, 0x2412})
        /ws/alexkr-sjc/emu/src/emu/core/veth_zmq.go:314 +0x193
emu/core.(*CThreadCtx).MainLoop(0xc0001fb008)
        /ws/alexkr-sjc/emu/src/emu/core/thread_ctx.go:393 +0x1a2
main.RunCoreZmq(0xc000090360)
        /ws/alexkr-sjc/emu/src/cmd/trex-emu.go:184 +0x44d
main.main()
        /ws/alexkr-sjc/emu/src/cmd/trex-emu.go:206 +0x71

goroutine 7 [chan send]:
emu/core.(*VethIFZmq).rxThread(0xc00026e2d0)
        /ws/alexkr-sjc/emu/src/emu/core/veth_zmq.go:140 +0x7d
created by emu/core.(*VethIFZmq).StartRxThread in goroutine 1
        /ws/alexkr-sjc/emu/src/emu/core/veth_zmq.go:129 +0x4f

goroutine 8 [sleep]:
time.Sleep(0x989680)
        /ws/alexkr-sjc/go/src/runtime/time.go:338 +0x165
emu/core.(*CZmqJsonRPC2).rxThread(0xc0001fb090)
        /ws/alexkr-sjc/emu/src/emu/core/rpc.go:88 +0x56
created by emu/core.(*CZmqJsonRPC2).StartRxThread in goroutine 1
        /ws/alexkr-sjc/emu/src/emu/core/rpc.go:105 +0x4f

